### PR TITLE
Updating Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,6 +2,7 @@
 FROM openjdk:17 AS build
 WORKDIR /app
 COPY . .
+RUN chmod +x mvnw
 RUN ./mvnw clean install -DskipTests
 
 # Runtime stage


### PR DESCRIPTION
Issue : https://github.com/andrew2k4/Employees-manager/issues/1

fix(docker): add executable permissions to mvnw for successful build

Problem:
The Docker build process was failing with the error: "/bin/sh: ./mvnw: Permission denied". This was due to the `mvnw` file not having the appropriate executable permissions when copied into the Docker image.

Solution:
- Updated the `Dockerfile` to explicitly set executable permissions for the `mvnw` file using `RUN chmod +x mvnw`.
- Ensured the file is executable locally before building the Docker image.

Impact:
This fix allows the Docker build process to complete successfully by ensuring the `mvnw` file can be executed during the build.

Commands added:
```dockerfile
RUN chmod +x mvnw